### PR TITLE
Remove unnecessary public directory copy from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY package.json pnpm-lock.yaml ./
 COPY next.config.mjs postcss.config.mjs tailwind.config.ts tsconfig.json ./
 
 COPY ./prisma ./prisma
-COPY ./public ./public
 COPY ./src ./src
 COPY ./.env ./.env
 


### PR DESCRIPTION
Eliminate the copy command for the public directory in the Dockerfile to streamline the build process.