### PR TITLE
Add random seed functionality and refactor components

### DIFF
--- a/src/actions/create-random-seed.ts
+++ b/src/actions/create-random-seed.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { prisma } from "@/utilities";
+
+import type { Mission, User } from "@prisma";
+
+export async function createRandomSeed({
+  userId,
+  missionId,
+  number,
+}: {
+  userId: User["id"];
+  missionId: Mission["id"];
+  number: number;
+}) {
+  return await prisma.randomSeed.create({
+    data: {
+      userId,
+      missionId,
+      number,
+    },
+  });
+}

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -88,7 +88,7 @@ export default function SignUpPage() {
         } else {
           toast.error({
             title: "회원가입 실패",
-            description: `${error}`,
+            description: error,
           });
         }
       }

--- a/src/components/base/toast.tsx
+++ b/src/components/base/toast.tsx
@@ -7,13 +7,14 @@ import {
   XCircleIcon,
 } from "@heroicons/react/16/solid";
 import clsx from "clsx";
+import { isPlainObject, isPrimitive, isSymbol } from "es-toolkit";
 import React from "react";
 import { toast as sonnerToast } from "sonner";
 
 interface ToastProps {
   id: string | number;
   title: string;
-  description: string;
+  description: string | unknown;
   level: "info" | "warn" | "success" | "error";
   button?: {
     label: string;
@@ -43,7 +44,7 @@ function Toast({ id, title, description, level }: ToastProps) {
         level === "info" && "bg-blue-50",
         level === "warn" && "bg-yellow-50",
         level === "success" && "bg-green-50",
-        level === "error" && "bg-red-50"
+        level === "error" && "bg-red-50",
       )}
     >
       <div className="flex">
@@ -77,7 +78,7 @@ function Toast({ id, title, description, level }: ToastProps) {
               level === "info" && "text-blue-800",
               level === "warn" && "text-yellow-800",
               level === "success" && "text-green-800",
-              level === "error" && "text-red-800"
+              level === "error" && "text-red-800",
             )}
           >
             {title}
@@ -88,10 +89,16 @@ function Toast({ id, title, description, level }: ToastProps) {
               level === "info" && "text-blue-700",
               level === "warn" && "text-yellow-700",
               level === "success" && "text-green-700",
-              level === "error" && "text-red-700"
+              level === "error" && "text-red-700",
             )}
           >
-            <p>{description}</p>
+            <p>
+              {isPrimitive(description) && !isSymbol(description)
+                ? description
+                : isPlainObject(description) && "message" in description
+                  ? (description.message as string)
+                  : "알 수 없음"}
+            </p>
           </div>
         </div>
       </div>

--- a/src/components/feature/index.ts
+++ b/src/components/feature/index.ts
@@ -4,5 +4,3 @@ export * from "./settings";
 
 export * from "./user-dropdown";
 export * from "./users-combobox";
-export * from "./vote-button";
-export * from "./vote-dialog";

--- a/src/components/feature/mission-card-list/mission-card.tsx
+++ b/src/components/feature/mission-card-list/mission-card.tsx
@@ -23,7 +23,7 @@ import { useMission, useUser } from "@/swr";
 
 import type { Mission } from "@prisma";
 
-import { VoteButton } from "./vote-button";
+import { RandomSeedButton } from "./random-seed-button";
 
 export function MissionCard({ id }: { id: Mission["id"] }) {
   const { data: mission } = useMission({ id });
@@ -41,10 +41,10 @@ export function MissionCard({ id }: { id: Mission["id"] }) {
             <ShieldCheckIcon className="hidden fill-lime-500 sm:block" /> 완료
           </Button>
         ) : (
-          <VoteButton className="shrink-0 text-sm" outline>
+          <RandomSeedButton className="shrink-0 text-sm" outline>
             <ShieldExclamationIcon className="hidden fill-rose-500 sm:block" />
             난수 만들기
-          </VoteButton>
+          </RandomSeedButton>
         )}
       </CardHeader>
       <CardBody>

--- a/src/components/feature/mission-card-list/mission-card.tsx
+++ b/src/components/feature/mission-card-list/mission-card.tsx
@@ -19,10 +19,11 @@ import {
   TableRow,
   Text,
 } from "@/components/base";
-import { VoteButton } from "@/components/feature";
 import { useMission, useUser } from "@/swr";
 
 import type { Mission } from "@prisma";
+
+import { VoteButton } from "./vote-button";
 
 export function MissionCard({ id }: { id: Mission["id"] }) {
   const { data: mission } = useMission({ id });

--- a/src/components/feature/mission-card-list/mission-card.tsx
+++ b/src/components/feature/mission-card-list/mission-card.tsx
@@ -41,7 +41,7 @@ export function MissionCard({ id }: { id: Mission["id"] }) {
             <ShieldCheckIcon className="hidden fill-lime-500 sm:block" /> 완료
           </Button>
         ) : (
-          <RandomSeedButton className="shrink-0 text-sm" outline>
+          <RandomSeedButton className="shrink-0 text-sm" outline missionId={id}>
             <ShieldExclamationIcon className="hidden fill-rose-500 sm:block" />
             난수 만들기
           </RandomSeedButton>

--- a/src/components/feature/mission-card-list/mission-create-button.tsx
+++ b/src/components/feature/mission-card-list/mission-create-button.tsx
@@ -3,8 +3,9 @@
 import { DocumentPlusIcon } from "@heroicons/react/16/solid";
 import { useState } from "react";
 
-import { MissionCreateDialog } from "..";
-import { Button } from "../../base";
+import { Button } from "@/components/base";
+
+import { MissionCreateDialog } from "../";
 
 export function MissionCreateButton() {
   const [open, setOpen] = useState(false);
@@ -12,7 +13,7 @@ export function MissionCreateButton() {
     <>
       <Button
         outline
-        className="min-h-40 border-2 border-dashed flex-col items-center"
+        className="min-h-40 flex-col items-center border-2 border-dashed"
         onClick={() => setOpen((v) => !v)}
       >
         <div className="size-12">

--- a/src/components/feature/mission-card-list/random-seed-button.tsx
+++ b/src/components/feature/mission-card-list/random-seed-button.tsx
@@ -5,9 +5,9 @@ import { useState } from "react";
 
 import { Button } from "@/components/base";
 
-import { VoteDialog } from "./vote-dialog";
+import { RandomSeedDialog } from "./random-seed-dialog";
 
-export function VoteButton({
+export function RandomSeedButton({
   className,
   children,
   ...props
@@ -22,7 +22,7 @@ export function VoteButton({
       >
         {children}
       </Button>
-      <VoteDialog open={isOpen} onClose={setIsOpen} />
+      <RandomSeedDialog open={isOpen} onClose={setIsOpen} />
     </>
   );
 }

--- a/src/components/feature/mission-card-list/random-seed-button.tsx
+++ b/src/components/feature/mission-card-list/random-seed-button.tsx
@@ -5,13 +5,18 @@ import { useState } from "react";
 
 import { Button } from "@/components/base";
 
+import type { Mission } from "@prisma";
+
 import { RandomSeedDialog } from "./random-seed-dialog";
 
 export function RandomSeedButton({
+  missionId,
   className,
   children,
   ...props
-}: React.ComponentPropsWithoutRef<typeof Button>) {
+}: { missionId: Mission["id"] } & React.ComponentPropsWithoutRef<
+  typeof Button
+>) {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
@@ -22,7 +27,11 @@ export function RandomSeedButton({
       >
         {children}
       </Button>
-      <RandomSeedDialog open={isOpen} onClose={setIsOpen} />
+      <RandomSeedDialog
+        missionId={missionId}
+        open={isOpen}
+        onClose={setIsOpen}
+      />
     </>
   );
 }

--- a/src/components/feature/mission-card-list/random-seed-dialog.tsx
+++ b/src/components/feature/mission-card-list/random-seed-dialog.tsx
@@ -34,9 +34,9 @@ export function RandomSeedDialog({
     });
 
   const onSubmit = useCallback(
-    async (number: number) => {
+    async (seedNumber: number) => {
       try {
-        const randomSeed = await createRandomSeed({ number });
+        const randomSeed = await createRandomSeed({ seedNumber });
         toast.success({
           title: "난수 만들기 성공",
           description: randomSeed.createdAt.toLocaleString(),
@@ -79,7 +79,6 @@ export function RandomSeedDialog({
           type="number"
           min={0}
           max={99}
-          maxLength={2}
           value={seed}
           onChange={(e) => setSeed(e.target.value.substring(0, 2))}
         />

--- a/src/components/feature/mission-card-list/random-seed-dialog.tsx
+++ b/src/components/feature/mission-card-list/random-seed-dialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from "@/components/base";
 
-export function VoteDialog({
+export function RandomSeedDialog({
   open,
   onClose,
 }: Omit<React.ComponentPropsWithoutRef<typeof Dialog>, "children">) {

--- a/src/components/feature/mission-card-list/vote-button.tsx
+++ b/src/components/feature/mission-card-list/vote-button.tsx
@@ -3,8 +3,9 @@
 import clsx from "clsx";
 import { useState } from "react";
 
-import { VoteDialog } from "./";
-import { Button } from "../base";
+import { Button } from "@/components/base";
+
+import { VoteDialog } from "./vote-dialog";
 
 export function VoteButton({
   className,

--- a/src/components/feature/mission-card-list/vote-dialog.tsx
+++ b/src/components/feature/mission-card-list/vote-dialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogActions,
   DialogBody,
   DialogTitle,
-} from "../base";
+} from "@/components/base";
 
 export function VoteDialog({
   open,
@@ -31,9 +31,9 @@ export function VoteDialog({
             <div
               key={i}
               className={clsx(
-                "rounded-md p-1 w-[1em] h-[1.2em] shadow text-6xl text-center font-mono",
+                "h-[1.2em] w-[1em] rounded-md p-1 text-center font-mono text-6xl shadow",
                 "bg-transparent dark:bg-white/5",
-                "border border-zinc-950/10 dark:border-white/10"
+                "border border-zinc-950/10 dark:border-white/10",
               )}
               onClick={() => inputRef.current?.focus()}
             >

--- a/src/components/feature/mission-create-dialog/dialog.tsx
+++ b/src/components/feature/mission-create-dialog/dialog.tsx
@@ -74,7 +74,7 @@ export function MissionCreateDialog({
         });
         close();
       } catch (error) {
-        toast.error({ title: "미션 생성 실패", description: `${error}` });
+        toast.error({ title: "미션 생성 실패", description: error });
       }
     },
     [close, createMission, members, roles],

--- a/src/components/feature/settings/organization/organization-settings.tsx
+++ b/src/components/feature/settings/organization/organization-settings.tsx
@@ -77,7 +77,7 @@ export function OrganizationSettings({ id }: { id: Organization["id"] }) {
       } catch (error) {
         toast.error({
           title: "업데이트 실패",
-          description: `${error}`,
+          description: error,
         });
       }
     },
@@ -100,7 +100,7 @@ export function OrganizationSettings({ id }: { id: Organization["id"] }) {
         } catch (error) {
           toast.error({
             title: "초대하기 실패",
-            description: `${error}`,
+            description: error,
           });
         }
       }
@@ -121,7 +121,7 @@ export function OrganizationSettings({ id }: { id: Organization["id"] }) {
         } catch (error) {
           toast.error({
             title: "내보내기 실패",
-            description: `${error}`,
+            description: error,
           });
         }
       }

--- a/src/swr/index.ts
+++ b/src/swr/index.ts
@@ -4,5 +4,6 @@ export * from "./use-organization-creation";
 export * from "./use-organization-mutation";
 export * from "./use-organization";
 export * from "./use-organizations";
+export * from "./use-random-seed";
 export * from "./use-user";
 export * from "./use-users";

--- a/src/swr/use-random-seed.ts
+++ b/src/swr/use-random-seed.ts
@@ -1,8 +1,11 @@
+import { mutate } from "swr";
 import useSWRMutation from "swr/mutation";
 
 import { createRandomSeed } from "@/actions/create-random-seed";
 
 import type { Mission, RandomSeed, User } from "@prisma";
+
+import { SWR_KEY_MISSIONS } from "./use-missions";
 
 export const SWR_KEY_RANDOM_SEED = (
   userId: User["id"],
@@ -13,7 +16,9 @@ async function createFetcher(
   [, userId, missionId]: ReturnType<typeof SWR_KEY_RANDOM_SEED>,
   { arg: { number } }: { arg: { number: RandomSeed["number"] } },
 ) {
-  return await createRandomSeed({ userId, missionId, number });
+  const randomSeed = await createRandomSeed({ userId, missionId, number });
+  mutate(SWR_KEY_MISSIONS(userId));
+  return randomSeed;
 }
 
 export function useRandomSeedCreation({

--- a/src/swr/use-random-seed.ts
+++ b/src/swr/use-random-seed.ts
@@ -14,9 +14,13 @@ export const SWR_KEY_RANDOM_SEED = (
 
 async function createFetcher(
   [, userId, missionId]: ReturnType<typeof SWR_KEY_RANDOM_SEED>,
-  { arg: { number } }: { arg: { number: RandomSeed["number"] } },
+  { arg: { seedNumber } }: { arg: { seedNumber: RandomSeed["number"] } },
 ) {
-  const randomSeed = await createRandomSeed({ userId, missionId, number });
+  const randomSeed = await createRandomSeed({
+    userId,
+    missionId,
+    number: seedNumber,
+  });
   mutate(SWR_KEY_MISSIONS(userId));
   return randomSeed;
 }

--- a/src/swr/use-random-seed.ts
+++ b/src/swr/use-random-seed.ts
@@ -1,0 +1,27 @@
+import useSWRMutation from "swr/mutation";
+
+import { createRandomSeed } from "@/actions/create-random-seed";
+
+import type { Mission, RandomSeed, User } from "@prisma";
+
+export const SWR_KEY_RANDOM_SEED = (
+  userId: User["id"],
+  missionId: Mission["id"],
+) => ["SWR_RANDOM_SEED", userId, missionId];
+
+async function createFetcher(
+  [, userId, missionId]: ReturnType<typeof SWR_KEY_RANDOM_SEED>,
+  { arg: { number } }: { arg: { number: RandomSeed["number"] } },
+) {
+  return await createRandomSeed({ userId, missionId, number });
+}
+
+export function useRandomSeedCreation({
+  userId,
+  missionId,
+}: {
+  userId: User["id"];
+  missionId: Mission["id"];
+}) {
+  return useSWRMutation(SWR_KEY_RANDOM_SEED(userId, missionId), createFetcher);
+}


### PR DESCRIPTION
Introduce `RandomSeedButton` and `RandomSeedDialog` components for creating random seeds. Refactor `MissionCard` to replace the `VoteButton` with the new `RandomSeedButton`. Update error handling in toasts for better clarity. Clean up imports and enhance mission data mutation after seed generation.

<img width="24%" src="https://github.com/user-attachments/assets/8c467668-3b2a-4f53-b151-88778885d2a5" />
<img width="24%" src="https://github.com/user-attachments/assets/aca7c83e-1c49-4de5-a153-2b6e26d2e2b9" />
<img width="24%" src="https://github.com/user-attachments/assets/7f346feb-05c8-42b5-8ba8-7b13e01e934c" />
<img width="24%" src="https://github.com/user-attachments/assets/c59c3edb-5f5a-4d65-b2f0-2db9b2b5a146" />
