### PR TITLE
Rename soldierId and name to username and nickname in user components

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,9 +10,9 @@ datasource db {
 
 model User {
   id         String   @id @default(uuid())
-  soldierId  String
+  username   String
+  nickname   String
   unit       String
-  name       String
   rank       String
   birthday   DateTime
   enlistedAt DateTime

--- a/src/actions/create-user.ts
+++ b/src/actions/create-user.ts
@@ -4,21 +4,21 @@ import { prisma } from "@/utilities";
 
 export async function createUser({
   id,
-  soldierId,
   unit,
-  name,
+  username,
+  nickname,
   birthday,
   enlistedAt,
 }: {
   id: string;
-  soldierId: string;
   unit: string;
-  name: string;
+  username: string;
+  nickname: string;
   birthday: Date;
   enlistedAt: Date;
 }) {
   const user = await prisma.user.create({
-    data: { id, soldierId, unit, rank: "이병", name, birthday, enlistedAt },
+    data: { id, unit, username, nickname, rank: "이병", birthday, enlistedAt },
   });
   return user;
 }

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -31,15 +31,15 @@ export default function SignInPage() {
 
   const [isLoading, setIsLoading] = useState(false);
   const onSubmit = useCallback<SubmitHandler<Inputs>>(
-    async ({ soldierId, password }) => {
+    async ({ username, password }) => {
       if (!isLoading) {
         setIsLoading(true);
         try {
           await setPersistence(firebaseAuth, browserSessionPersistence);
           const userCredential = await signInWithEmailAndPassword(
             firebaseAuth,
-            `${soldierId}@${emailDomain}`,
-            password
+            `${username}@${emailDomain}`,
+            password,
           );
           if (userCredential.user.uid) {
             toast.success({
@@ -63,7 +63,7 @@ export default function SignInPage() {
         }
       }
     },
-    [isLoading, setIsLoading, router]
+    [isLoading, setIsLoading, router],
   );
 
   const {
@@ -83,11 +83,11 @@ export default function SignInPage() {
         <Label>군번</Label>
         <Input
           type="text"
-          invalid={!!errors.soldierId}
-          {...register("soldierId", { required: "군번을 입력해주세요" })}
+          invalid={!!errors.username}
+          {...register("username", { required: "아이디를 입력해주세요" })}
         />
-        {errors.soldierId && (
-          <ErrorMessage>{errors.soldierId.message}</ErrorMessage>
+        {errors.username && (
+          <ErrorMessage>{errors.username.message}</ErrorMessage>
         )}
       </Field>
       <Field>
@@ -115,6 +115,6 @@ export default function SignInPage() {
 }
 
 type Inputs = {
-  soldierId: string;
+  username: string;
   password: string;
 };

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -29,24 +29,24 @@ import type { SubmitHandler } from "react-hook-form";
 async function signUp(
   url: string,
   {
-    arg: { soldierId, unit, name, password, birthday, enlistedAt },
+    arg: { unit, username, nickname, password, birthday, enlistedAt },
   }: {
     arg: Inputs;
   },
 ) {
   const { user: firebaseUser } = await createUserWithEmailAndPassword(
     firebaseAuth,
-    `${soldierId}@${emailDomain}`,
+    `${username}@${emailDomain}`,
     password,
   );
   await updateProfile(firebaseUser, {
-    displayName: name,
+    displayName: nickname,
   });
   const user = await createUser({
     id: firebaseUser.uid,
-    soldierId,
     unit,
-    name,
+    username,
+    nickname,
     birthday: new Date(birthday),
     enlistedAt: new Date(enlistedAt),
   });
@@ -76,7 +76,7 @@ export default function SignUpPage() {
         const user = await trigger(props);
         toast.success({
           title: "회원가입 성공",
-          description: `${user.name}님 환영합니다`,
+          description: `${user.nickname}님 환영합니다`,
         });
         router.push("/");
       } catch (error) {
@@ -103,14 +103,14 @@ export default function SignUpPage() {
     >
       <Heading>회원가입</Heading>
       <Field>
-        <Label>군번</Label>
+        <Label>아이디</Label>
         <Input
           type="text"
-          invalid={!!errors.soldierId}
-          {...register("soldierId", { required: "군번을 입력해주세요" })}
+          invalid={!!errors.username}
+          {...register("username", { required: "아이디를 입력해주세요" })}
         />
-        {errors.soldierId && (
-          <ErrorMessage>{errors.soldierId.message}</ErrorMessage>
+        {errors.username && (
+          <ErrorMessage>{errors.username.message}</ErrorMessage>
         )}
       </Field>
       <Field>
@@ -135,10 +135,12 @@ export default function SignUpPage() {
         <Label>이름</Label>
         <Input
           type="text"
-          invalid={!!errors.name}
-          {...register("name", { required: "이름을 입력해주세요" })}
+          invalid={!!errors.nickname}
+          {...register("nickname", { required: "이름을 입력해주세요" })}
         />
-        {errors.name && <ErrorMessage>{errors.name.message}</ErrorMessage>}
+        {errors.nickname && (
+          <ErrorMessage>{errors.nickname.message}</ErrorMessage>
+        )}
       </Field>
       <Field>
         <Label>비밀번호</Label>
@@ -205,9 +207,9 @@ export default function SignUpPage() {
 }
 
 type Inputs = {
-  soldierId: string;
   unit: string;
-  name: string;
+  username: string;
+  nickname: string;
   password: string;
   passwordConfirm: string;
   birthday: string;

--- a/src/components/feature/mission-card-list/mission-card.tsx
+++ b/src/components/feature/mission-card-list/mission-card.tsx
@@ -59,7 +59,7 @@ export function MissionCard({ id }: { id: Mission["id"] }) {
             {mission?.participants.map(({ user: p }) => {
               return (
                 <TableRow key={p.id}>
-                  <TableCell>{p.name}</TableCell>
+                  <TableCell>{p.nickname}</TableCell>
                   <TableCell className="flex items-center justify-between">
                     {p.exempts.length ? (
                       <Badge color="zinc">{p.exempts[0].excuse.reason}</Badge>

--- a/src/components/feature/mission-create-dialog/field-members.tsx
+++ b/src/components/feature/mission-create-dialog/field-members.tsx
@@ -44,15 +44,15 @@ export function FieldMembers({
         <Combobox
           value={member}
           options={users ?? []}
-          displayValue={(u) => u?.name}
+          displayValue={(u) => u?.nickname}
           onChange={(u) => setMember(u)}
         >
           {(u) => (
             <ComboboxOption value={u}>
               <ComboboxLabel>
-                {u.rank} {u.name}
+                {u.rank} {u.nickname}
               </ComboboxLabel>
-              <ComboboxDescription>{u.soldierId}</ComboboxDescription>
+              <ComboboxDescription>{u.username}</ComboboxDescription>
             </ComboboxOption>
           )}
         </Combobox>
@@ -85,9 +85,9 @@ export function FieldMembers({
             {members.map((member) => (
               <TableRow key={member.id}>
                 <TableCell>{member.rank}</TableCell>
-                <TableCell>{member.name}</TableCell>
+                <TableCell>{member.nickname}</TableCell>
                 <TableCell className="text-zinc-500">
-                  {member.soldierId}
+                  {member.username}
                 </TableCell>
                 <TableCell>
                   <div className="-mx-3 -my-1.5 sm:-mx-2.5">

--- a/src/components/feature/settings/organization/organization-settings.tsx
+++ b/src/components/feature/settings/organization/organization-settings.tsx
@@ -115,7 +115,7 @@ export function OrganizationSettings({ id }: { id: Organization["id"] }) {
           await deleteMember({ id: member.id });
           toast.success({
             title: "내보내기 성공",
-            description: `${member.user.name}은 더이상 ${organization?.name}의 멤버가 아닙니다.`,
+            description: `${member.user.nickname}은 더이상 ${organization?.name}의 멤버가 아닙니다.`,
           });
           setDeletionMember(null);
         } catch (error) {
@@ -230,7 +230,7 @@ export function OrganizationSettings({ id }: { id: Organization["id"] }) {
                       <TableCell>{member.user.unit}</TableCell>
                       <TableCell>{member.user.rank}</TableCell>
                       <TableCell>
-                        {member.user.name}
+                        {member.user.nickname}
                         {member.isLeader && (
                           <Badge className="ml-1" color="lime">
                             팀장
@@ -257,7 +257,7 @@ export function OrganizationSettings({ id }: { id: Organization["id"] }) {
               >
                 <DialogTitle>이 결정은 되돌릴 수 없습니다.</DialogTitle>
                 <DialogDescription>
-                  {deletionMember?.user.name}을 {organization?.name}에서
+                  {deletionMember?.user.nickname}을 {organization?.name}에서
                   내보내시겠습니까?
                 </DialogDescription>
                 <DialogActions>

--- a/src/components/feature/user-dropdown.tsx
+++ b/src/components/feature/user-dropdown.tsx
@@ -31,7 +31,7 @@ export function UserDropdown() {
           disabled={isLoading}
           className="flex h-8 w-24 items-center justify-end"
         >
-          {user.name}
+          {user.nickname}
           <ChevronDownIcon />
         </DropdownButton>
       ) : (

--- a/src/components/feature/users-combobox.tsx
+++ b/src/components/feature/users-combobox.tsx
@@ -23,11 +23,11 @@ export function UsersCombobox({
       {...props}
       disabled={disabled || isLoadingUsers}
       options={users ?? []}
-      displayValue={(user) => user?.name}
+      displayValue={(user) => user?.nickname}
     >
       {(user) => (
         <ComboboxOption value={user}>
-          <ComboboxLabel>{user.name}</ComboboxLabel>
+          <ComboboxLabel>{user.nickname}</ComboboxLabel>
           <ComboboxDescription>{user.unit}</ComboboxDescription>
         </ComboboxOption>
       )}


### PR DESCRIPTION
Update user-related components to use username and nickname instead of soldierId and name for improved clarity and consistency.