### PR TITLE
Ensure team member list field spans full width in ParticipantSection

### DIFF
--- a/src/components/feature/mission/participant-section.tsx
+++ b/src/components/feature/mission/participant-section.tsx
@@ -91,7 +91,7 @@ export function ParticipantSection({ id }: { id: Mission["id"] }) {
             </Button>
           </div>
         </Field>
-        <Field>
+        <Field className="col-span-full">
           <Label>팀원 목록</Label>
           <div data-slot="control">
             <Table


### PR DESCRIPTION
Modify the ParticipantSection to ensure the team member list field utilizes the full width of its container.